### PR TITLE
Escape apostrophes in JSON before passing to shell curl command

### DIFF
--- a/scripts/updatePublications.pl
+++ b/scripts/updatePublications.pl
@@ -218,7 +218,9 @@ if ( scalar(@newTags) > 0 ) {
     };
     my $json = encode_json($data);
     (my $jsonEscaped = $json) =~ s/'/'\\''/g;
-    system("curl -X POST -H 'Content-type: application/json' --data '".$jsonEscaped."' ".$slackURL);
+    my $curlStatus = system("curl -X POST -H 'Content-type: application/json' --data '".$jsonEscaped."' ".$slackURL);
+    warn("Warning: curl exited with status ".($curlStatus >> 8)." when sending Slack notification\n")
+	if $curlStatus != 0;
 } else {
     print "No new tags to be created\n";
 }

--- a/scripts/updatePublications.pl
+++ b/scripts/updatePublications.pl
@@ -217,7 +217,8 @@ if ( scalar(@newTags) > 0 ) {
 	tags => join("\n",@newTags)."\n"
     };
     my $json = encode_json($data);
-    system("curl -X POST -H 'Content-type: application/json' --data '".$json."' ".$slackURL);
+    (my $jsonEscaped = $json) =~ s/'/'\\''/g;
+    system("curl -X POST -H 'Content-type: application/json' --data '".$jsonEscaped."' ".$slackURL);
 } else {
     print "No new tags to be created\n";
 }


### PR DESCRIPTION
Paper titles containing apostrophes broke the system() call at line 220
because the JSON was embedded in a single-quoted shell string. Replace
each ' with '\'' so the shell interprets them correctly.

https://claude.ai/code/session_01X1uuJ2FJaHMy4cnJ5Uj3G2