### PR TITLE
Add datasetsCommit field to publication schema

### DIFF
--- a/scripts/updatePublications.py
+++ b/scripts/updatePublications.py
@@ -17,13 +17,14 @@ import xml.etree.ElementTree as ET
 
 # Schema for entries in publications.xml. Validated on read and before write.
 PUBLICATION_REQUIRED = ("author", "commit", "title", "year")
-PUBLICATION_OPTIONAL = ("arXiv", "bibCode", "doi", "journalURL")
+PUBLICATION_OPTIONAL = ("arXiv", "bibCode", "datasetsCommit", "doi", "journalURL")
 PUBLICATION_PATTERNS = {
-    "year":       r"^\d{4}$",
-    "commit":     r"^[0-9a-f]{40}$",
-    "arXiv":      r"^(?:\d{4}\.\d{4,5}|[\w\-]+/\d{7})$",
-    "doi":        r"^10\.\d+/\S+$",
-    "journalURL": r"^https?://",
+    "year":           r"^\d{4}$",
+    "commit":         r"^[0-9a-f]{40}$",
+    "datasetsCommit": r"^[0-9a-f]{40}$",
+    "arXiv":          r"^(?:\d{4}\.\d{4,5}|[\w\-]+/\d{7})$",
+    "doi":            r"^10\.\d+/\S+$",
+    "journalURL":     r"^https?://",
 }
 
 


### PR DESCRIPTION
## Summary
Added support for an optional `datasetsCommit` field in the publications schema to track dataset-related commits alongside publication commits.

## Key Changes
- Added `datasetsCommit` to `PUBLICATION_OPTIONAL` tuple
- Added validation pattern for `datasetsCommit` field (40-character hexadecimal SHA-1 hash, matching the existing `commit` pattern)
- Reformatted `PUBLICATION_PATTERNS` dictionary with consistent alignment for improved readability

## Implementation Details
The `datasetsCommit` field follows the same validation rules as the existing `commit` field, requiring a valid 40-character hexadecimal string (SHA-1 hash format). This allows publications to optionally reference associated datasets via their commit hashes.

https://claude.ai/code/session_01RPbPMNPRn7a2jvrWtTFzti